### PR TITLE
Import Fixes and Button Numbering (that you mentioned during the workshop)

### DIFF
--- a/src/app/samples/basic/basics.component.ts
+++ b/src/app/samples/basic/basics.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
     <button (click)="demo='02'">2</button>
     <button (click)="demo='03'">3</button>
     <button (click)="demo='04'">4</button>
-    <button (click)="demo='05'">6</button>
+    <button (click)="demo='05'">5</button>
     <button (click)="demo='06'">6</button>
     <button (click)="demo='07'">7</button>
   </div>

--- a/src/app/samples/play/01-map.ts
+++ b/src/app/samples/play/01-map.ts
@@ -2,7 +2,7 @@
 // tslint:disable:member-ordering
 // Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 // #endregion imports
 
 export function play(...args) {
@@ -10,7 +10,7 @@ export function play(...args) {
   const numbers$ = Rxjs.of(10, 20, 30, 40, 50);
 
   const observable$ = numbers$.pipe(
-    op.map(n => n * 2)
+    map(n => n * 2)
   );
 
   return observable$;

--- a/src/app/samples/play/01a-map-to-something.ts
+++ b/src/app/samples/play/01a-map-to-something.ts
@@ -2,7 +2,7 @@
 // tslint:disable:member-ordering
 // Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 // #endregion imports
 
 export function play(...args) {
@@ -10,7 +10,7 @@ export function play(...args) {
   const numbers$ = Rxjs.of(10, 20, 30, 40, 50);
 
   const observable$ = numbers$.pipe(
-    op.map(n => {
+    map(n => {
       switch (n) {
         case 0: return 'nothing';
         case 10: return 'ten';

--- a/src/app/samples/play/02-throw.ts
+++ b/src/app/samples/play/02-throw.ts
@@ -2,7 +2,7 @@
 // tslint:disable:member-ordering
 // Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 // #endregion imports
 
 export function play(...args) {
@@ -10,7 +10,7 @@ export function play(...args) {
   const numbers$ = Rxjs.of(10, 20, 30, 40, 50);
 
   const observable$ = numbers$.pipe(
-    op.map(_ => { throw new Error('Errorrrr'); })
+    map(_ => { throw new Error('Errorrrr'); })
   );
 
   return observable$;

--- a/src/app/samples/play/03-throwError.ts
+++ b/src/app/samples/play/03-throwError.ts
@@ -2,7 +2,7 @@
 // tslint:disable:member-ordering
 // Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 // #endregion imports
 
 export function play(...args) {
@@ -11,7 +11,7 @@ export function play(...args) {
 
   const observable$ = numbers$.pipe(
     // DISCUSS: Do you know why concatMap and not map?
-    op.concatMap(_ => Rxjs.throwError('throwErrorrrrrr'))
+    concatMap(_ => Rxjs.throwError('throwErrorrrrrr'))
   );
 
   return observable$;

--- a/src/app/samples/play/04-array-magic.ts
+++ b/src/app/samples/play/04-array-magic.ts
@@ -1,4 +1,6 @@
+// #region imports
 import { of } from 'rxjs';
+// #endregion imports
 
 export function play(...args) {
 

--- a/src/app/samples/play/05-pipe-magic.ts
+++ b/src/app/samples/play/05-pipe-magic.ts
@@ -1,20 +1,18 @@
+// #region imports
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
-import { of, interval } from 'rxjs';
-
-import { filter, map, reduce, scan, take } from 'rxjs/operators';
-
+import { filter, map, reduce, take, scan } from 'rxjs/operators';
+import { interval } from 'rxjs';
 import { log } from '../helpers'; // if we need it.
+// #endregion imports
 
 export function play(...args) {
 
   const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-  const numbers$ = Rxjs.from(numbers);
-
+  // 3 different ways to create the Obsrvable:
+  // const numbers$ = Rxjs.from(numbers);
   // const numbers$ = Rxjs.from(numbers, Rxjs.asapScheduler);
-
-  // const numbers$ = interval(50); // tick tick tick
+  const numbers$ = interval(50); // tick tick tick
 
   /**
    * To double the odd integers and sum them ...

--- a/src/app/samples/play/06-scan-magic.ts
+++ b/src/app/samples/play/06-scan-magic.ts
@@ -1,6 +1,7 @@
-import { of, interval } from 'rxjs';
-
-import { filter, map, reduce, scan, take } from 'rxjs/operators';
+// #region imports
+import { interval } from 'rxjs';
+import { filter, map, scan, take } from 'rxjs/operators';
+// #endregion imports
 
 export function play(...args) {
 

--- a/src/app/samples/play/07-loggerOp.ts
+++ b/src/app/samples/play/07-loggerOp.ts
@@ -1,10 +1,8 @@
 // #region imports
 // tslint:disable:member-ordering
 import { Observable } from 'rxjs';
-
-// Namespace to get something you need
-import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
+// import * as op from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 // #endregion imports
 import { data$ } from '../helpers';
 
@@ -21,7 +19,7 @@ export const loggingObserver = (name?: string) => ({
 export const logOp = (name?: string) =>
   (o: Observable<any>) => o.pipe(
     // use the tap operator for side-effects
-    op.tap(loggingObserver(name))
+    tap(loggingObserver(name))
   );
 
 

--- a/src/app/samples/play/08-oddDoublerOp.ts
+++ b/src/app/samples/play/08-oddDoublerOp.ts
@@ -1,6 +1,5 @@
-import { Observable, of, interval } from 'rxjs';
-
-import { filter, map, reduce, scan, take } from 'rxjs/operators';
+import { Observable, interval } from 'rxjs';
+import { filter, map, reduce, take } from 'rxjs/operators';
 
 // #region Custom operators
 
@@ -18,6 +17,7 @@ const takeMaybe = (toTake?: number) => <T> (o: Observable<T>) => toTake ? o.pipe
  */
 export const oddDoublerOp = (toTake = 10) => (o: Observable<number>) =>
   o.pipe(
+    // Uses our custom operator in the context of Pipe
     takeMaybe(toTake),
     filter(i => i % 2 === 1),
     map(i => i * 2),

--- a/src/app/samples/play/10-subject.ts
+++ b/src/app/samples/play/10-subject.ts
@@ -1,8 +1,6 @@
 // #region imports
 // tslint:disable:member-ordering
-// Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
 // #endregion imports
 
 /**

--- a/src/app/samples/play/99-groupBy.ts
+++ b/src/app/samples/play/99-groupBy.ts
@@ -1,8 +1,7 @@
 // #region imports
 // tslint:disable:member-ordering
-// Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
+import { groupBy, mergeMap, map, reduce, concatMap } from 'rxjs/operators';
 // #endregion imports
 
 export function play(...args) {
@@ -18,13 +17,13 @@ export function play(...args) {
     {id: 1, name: 'typescript'},
     {id: 3, name: 'tslint'}
   ).pipe(
-    op.groupBy(p => p.id, p => p.name),
-    op.mergeMap( (group$) => group$.pipe(op.reduce((acc, cur) => [...acc, cur], ['' + group$.key]))),
-    op.map((arr: string[]) => ({'id': parseInt(arr[0], 10), 'values': arr.slice(1)})),
+    groupBy(p => p.id, p => p.name),
+    mergeMap( (group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], ['' + group$.key]))),
+    map((arr: string[]) => ({'id': parseInt(arr[0], 10), 'values': arr.slice(1)})),
 
 
-    // op.concatMap(_ => Rxjs.throwError('error'))
-    // op.map(_ => { throw new Error('Errorrrr'); })
+    // concatMap(_ => Rxjs.throwError('error'))
+    // map(_ => { throw new Error('Errorrrr'); })
   );
 
   return observable$;

--- a/src/app/samples/play/99-unsubscriber.ts
+++ b/src/app/samples/play/99-unsubscriber.ts
@@ -1,8 +1,6 @@
 // #region imports
 // tslint:disable:member-ordering
-// Namespace to get something you need
 import * as Rxjs from 'rxjs';
-import * as op from 'rxjs/operators';
 // #endregion imports
 
 // #region Producer Class


### PR DESCRIPTION
You mentioned 'these imports are done the wrong way, but it was faster'. I fixed the imports across the play samples to make it clearer for sharing with my team, thought I'd PR it.

(The branch is called "button-numbers", because I originally was just hopping on to fix the "double 6 issue" on the Basic examples.)